### PR TITLE
feat(play vs engine): Add support for engine auto-promotion

### DIFF
--- a/components/Chessboard.jsx
+++ b/components/Chessboard.jsx
@@ -1,5 +1,10 @@
 import classnames from 'merge-class-names';
-import { forwardRef, useEffect, useImperativeHandle, useRef } from 'react';
+import React, {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useRef
+} from 'react';
 import useChess from '../hooks/use-chess';
 import useChessground from '../hooks/use-chessground';
 import useDisclosure from '../hooks/use-disclosure';

--- a/components/Chessboard.jsx
+++ b/components/Chessboard.jsx
@@ -1,19 +1,15 @@
-import React, {
-  forwardRef,
-  useEffect,
-  useImperativeHandle,
-  useRef,
-} from 'react';
 import classnames from 'merge-class-names';
+import { forwardRef, useEffect, useImperativeHandle, useRef } from 'react';
+import useChess from '../hooks/use-chess';
+import useChessground from '../hooks/use-chessground';
+import useDisclosure from '../hooks/use-disclosure';
+import usePremove from '../hooks/use-premove';
 import Chessground from '../lib/Chessground';
 import audio from '../lib/audio';
-import useChessground from '../hooks/use-chessground';
-import useChess from '../hooks/use-chess';
-import usePremove from '../hooks/use-premove';
-import Promote from './Promote';
-import useDisclosure from '../hooks/use-disclosure';
 import cgProps from '../lib/cg-props';
+import isPromotion from '../utils/is-promotion';
 import toDests from '../utils/to-dests';
+import Promote from './Promote';
 
 const Chessboard = (props, ref) => {
   const { theme } = useChessground();
@@ -37,20 +33,12 @@ const Chessboard = (props, ref) => {
 
     // Try to make the move with the promotion piece (if any)
     const move = onMove(from, to, promotionPiece);
-
     if (!move) {
-      // Check if this is a promotion move
-      const piece = chess.get(from);
-      const isPromotion =
-        piece?.type === 'p' &&
-        ((piece.color === 'w' && to[1] === '8') ||
-          (piece.color === 'b' && to[1] === '1'));
-
-      if (isPromotion && !promotionPiece) {
+      // Check if this is a promotion move and show the promotion dialog if needed
+      const isPromotionMove = isPromotion(chess, from, to);
+      if (isPromotionMove && !promotionPiece) {
         show();
-        return false;
       }
-
       return false;
     }
 

--- a/examples/pages/play.js
+++ b/examples/pages/play.js
@@ -8,7 +8,7 @@ import coffee from '../lib/coffee';
 const Page = () => {
   const ref = useRef();
 
-  const [engine] = useState(new Stockfish('./stockfish.asm.js'));
+  const [engine] = useState(new Stockfish());
   useEffect(() => {
     engine.init();
   }, []);
@@ -49,7 +49,6 @@ const Page = () => {
           ref={ref}
           lastMove={lastMove}
           onMove={onMove}
-          fen="4k3/P7/8/8/8/8/P7/3nK3 w - - 0 1"
         />
         <div>
           <h2 className="text-xl mb-2">Code sample</h2>

--- a/examples/pages/play.js
+++ b/examples/pages/play.js
@@ -31,10 +31,7 @@ const Page = () => {
 
       setLastMove([move.from, move.to]);
       if (ref.current) {
-        await ref.current.move(move.from, move.to, {
-          autoPromote: true,
-          promotion: move.promotion,
-        });
+        await ref.current.move(move.from, move.to, move.promotion);
       }
 
       if (ref.current && ref.current.playPremove) {
@@ -52,6 +49,7 @@ const Page = () => {
           ref={ref}
           lastMove={lastMove}
           onMove={onMove}
+          fen="4k3/P7/8/8/8/8/P7/3nK3 w - - 0 1"
         />
         <div>
           <h2 className="text-xl mb-2">Code sample</h2>

--- a/examples/pages/play.js
+++ b/examples/pages/play.js
@@ -8,7 +8,7 @@ import coffee from '../lib/coffee';
 const Page = () => {
   const ref = useRef();
 
-  const [engine] = useState(new Stockfish());
+  const [engine] = useState(new Stockfish('./stockfish.asm.js'));
   useEffect(() => {
     engine.init();
   }, []);
@@ -31,7 +31,10 @@ const Page = () => {
 
       setLastMove([move.from, move.to]);
       if (ref.current) {
-        ref.current.move(move.from, move.to, move.promotion);
+        await ref.current.move(move.from, move.to, {
+          autoPromote: true,
+          promotion: move.promotion,
+        });
       }
 
       if (ref.current && ref.current.playPremove) {

--- a/examples/utils/code-samples/play.js
+++ b/examples/utils/code-samples/play.js
@@ -26,10 +26,7 @@ const Page = () => {
 
       setLastMove([move.from, move.to]);
       if (ref.current) {
-        await ref.current.move(move.from, move.to, {
-          autoPromote: true,
-          promotion: move.promotion,
-        });
+        await ref.current.move(move.from, move.to, move.promotion);
       }
 
       if (ref.current && ref.current.playPremove) {

--- a/examples/utils/code-samples/play.js
+++ b/examples/utils/code-samples/play.js
@@ -26,9 +26,12 @@ const Page = () => {
 
       setLastMove([move.from, move.to]);
       if (ref.current) {
-        ref.current.board.move(move.from, move.to);
+        await ref.current.move(move.from, move.to, {
+          autoPromote: true,
+          promotion: move.promotion,
+        });
       }
-        
+
       if (ref.current && ref.current.playPremove) {
         await coffee(100);
         await ref.current.playPremove();

--- a/hooks/use-premove.js
+++ b/hooks/use-premove.js
@@ -33,7 +33,7 @@ const usePremove = (handleMove) => {
       currentPremove.current = null;
 
       const metadata = {
-        isPremove: true,
+        autoPromote: true,
         promotion: premoveData.promotion || 'q',
       };
 

--- a/hooks/use-premove.js
+++ b/hooks/use-premove.js
@@ -33,7 +33,6 @@ const usePremove = (handleMove) => {
       currentPremove.current = null;
 
       const metadata = {
-        autoPromote: true,
         promotion: premoveData.promotion || 'q',
       };
 

--- a/utils/is-promotion.js
+++ b/utils/is-promotion.js
@@ -1,0 +1,19 @@
+/**
+ * Checks if a move is a pawn promotion.
+ */
+const isPromotion = (chess, from, to) => {
+  try {
+    const piece = chess.get(from);
+    if (piece.type !== 'p') {
+      return false;
+    }
+    return (
+      (piece.color === 'w' && to[1] === '8') ||
+      (piece.color === 'b' && to[1] === '1')
+    );
+  } catch {
+    return false;
+  }
+};
+
+module.exports = isPromotion;


### PR DESCRIPTION
The engine is able to perform auto-promotion to queen without displaying the promotion modal.