### PR TITLE
Fix board state reset on every React re-render

### DIFF
--- a/lib/Chessground.jsx
+++ b/lib/Chessground.jsx
@@ -59,13 +59,28 @@ export default class Chessground extends React.Component {
   }
 
   componentDidMount() {
-    this.board = NativeChessground(this.el, this.buildConfigFromProps(this.props));
+    this.board = NativeChessground(
+      this.el,
+      this.buildConfigFromProps(this.props)
+    );
     if (this.props.shapes) {
       this.board.setShapes(this.props.shapes);
     }
   }
-  componentDidUpdate() {
-    this.board = NativeChessground(this.el, this.buildConfigFromProps(this.props));
+  componentDidUpdate(prevProps) {
+    const config = this.buildConfigFromProps(this.props);
+
+    // Skip fen if unchanged to avoid resetting pieces mid-drag
+    if (this.props.fen === prevProps.fen) {
+      delete config.fen;
+    }
+
+    if (this.board) {
+      this.board.set(config);
+    } else {
+      this.board = NativeChessground(this.el, config);
+    }
+
     if (this.props.shapes) {
       this.board.setShapes(this.props.shapes);
     }


### PR DESCRIPTION
componentDidUpdate was calling NativeChessground() on every update, which creates a brand new chessground instance, destroying all internal state (selected piece, active drag, animation). This caused:

- Click-to-move failing intermittently (selected piece lost between clicks)
- Dragged pieces snapping back to origin when a re-render fires mid-drag

Fix: use board.set() to update config on existing instance instead of recreating it. Also skip passing fen when unchanged to prevent chessground from rebuilding pieces unnecessarily.